### PR TITLE
Use constant time string comparison routine from hmac module

### DIFF
--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -212,26 +212,30 @@ except ImportError:
     pass
 
 
-def constant_time_compare(val1, val2):
-    """
-    Returns True if the two strings are equal, False otherwise.
+try:
+    constant_time_compare = hmac.compare_digest
+except AttributeError:
+    # Fallback for Python < 2.7.7 and Python < 3.3
+    def constant_time_compare(val1, val2):
+        """
+        Returns True if the two strings are equal, False otherwise.
 
-    The time taken is independent of the number of characters that match.
-    """
-    if len(val1) != len(val2):
-        return False
+        The time taken is independent of the number of characters that match.
+        """
+        if len(val1) != len(val2):
+            return False
 
-    result = 0
+        result = 0
 
-    if sys.version_info >= (3, 0, 0):
-        # Bytes are numbers
-        for x, y in zip(val1, val2):
-            result |= x ^ y
-    else:
-        for x, y in zip(val1, val2):
-            result |= ord(x) ^ ord(y)
+        if sys.version_info >= (3, 0, 0):
+            # Bytes are numbers
+            for x, y in zip(val1, val2):
+                result |= x ^ y
+        else:
+            for x, y in zip(val1, val2):
+                result |= ord(x) ^ ord(y)
 
-    return result == 0
+        return result == 0
 
 
 def base64url_decode(input):


### PR DESCRIPTION
...and only use the current implementation as a fallback.

Fixes #63.