### PR TITLE
Invalid validation of audience claim

### DIFF
--- a/jwt/__init__.py
+++ b/jwt/__init__.py
@@ -434,6 +434,8 @@ def verify_signature(payload, signing_input, header, signature, key='',
             audience_claims = [audience_claims]
         if not isinstance(audience_claims, list):
             raise InvalidAudienceError('Invalid claim format in token')
+        if any(not isinstance(c, basestring) for c in audience_claims):
+            raise InvalidAudienceError('Invalid claim format in token')
         if audience not in audience_claims:
             raise InvalidAudienceError('Invalid audience')
     elif audience is not None:

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -701,93 +701,58 @@ class TestJWT(unittest.TestCase):
             self.assertFalse('ES512' in jwt.prepare_key_methods)
 
     def test_check_audience(self):
-        audience = 'urn:foo'
-
         payload = {
             'some': 'payload',
-            'aud': 'urn:foo'
+            'aud': 'urn:me'
         }
-
         token = jwt.encode(payload, 'secret')
-        decoded = jwt.decode(token, 'secret', audience=audience)
-
+        decoded = jwt.decode(token, 'secret', audience='urn:me')
         self.assertEqual(decoded, payload)
 
     def test_check_audience_in_array(self):
-        audience = ['urn:foo', 'urn:other']
-
         payload = {
             'some': 'payload',
-            'aud': 'urn:foo'
+            'aud': ['urn:me', 'urn:someone-else']
         }
-
         token = jwt.encode(payload, 'secret')
-        decoded = jwt.decode(token, 'secret', audience=audience)
-
+        decoded = jwt.decode(token, 'secret', audience='urn:me')
         self.assertEqual(decoded, payload)
 
     def test_raise_exception_invalid_audience(self):
-        audience = 'urn:wrong'
-
         payload = {
             'some': 'payload',
-            'aud': 'urn:foo'
+            'aud': 'urn:someone-else'
         }
-
         token = jwt.encode(payload, 'secret')
-
         self.assertRaises(
             jwt.InvalidAudienceError,
-            lambda: jwt.decode(token, 'secret', audience=audience))
+            lambda: jwt.decode(token, 'secret', audience='urn-me'))
 
     def test_raise_exception_invalid_audience_in_array(self):
-        audience = ['urn:wrong', 'urn:morewrong']
-
         payload = {
             'some': 'payload',
-            'aud': 'urn:foo'
+            'aud': ['urn:someone', 'urn:someone-else']
         }
-
         token = jwt.encode(payload, 'secret')
-
         self.assertRaises(
             jwt.InvalidAudienceError,
-            lambda: jwt.decode(token, 'secret', audience=audience))
+            lambda: jwt.decode(token, 'secret', audience='urn:me'))
 
     def test_raise_exception_token_without_audience(self):
-        audience = 'urn:wrong'
-
         payload = {
             'some': 'payload',
         }
-
         token = jwt.encode(payload, 'secret')
-
         self.assertRaises(
             jwt.InvalidAudienceError,
-            lambda: jwt.decode(token, 'secret', audience=audience))
-
-    def test_raise_exception_token_without_audience_in_array(self):
-        audience = ['urn:wrong', 'urn:morewrong']
-
-        payload = {
-            'some': 'payload',
-        }
-
-        token = jwt.encode(payload, 'secret')
-
-        self.assertRaises(
-            jwt.InvalidAudienceError,
-            lambda: jwt.decode(token, 'secret', audience=audience))
+            lambda: jwt.decode(token, 'secret', audience='urn:me'))
 
     def test_check_issuer(self):
         issuer = 'urn:foo'
-
         payload = {
             'some': 'payload',
             'iss': 'urn:foo'
         }
-
         token = jwt.encode(payload, 'secret')
         decoded = jwt.decode(token, 'secret', issuer=issuer)
 


### PR DESCRIPTION
The spec at http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#audDef states:

> The aud (audience) claim identifies the recipients that the JWT is intended for. Each principal intended to process the JWT MUST identify itself with a value in the audience claim. If the principal processing the claim does not identify itself with a value in the aud claim when this claim is present, then the JWT MUST be rejected.

As I understand it, Pyjwt doesn't seem to implement this requirement correctly. Basically it reverses the checks. Let me explain.

Pyjwt only checks the audience claim when an `audience=...` arg was specified to `decode()`, meaning that any `audience` claim in the JWT is blindly ignored if no such arg was passed. This results in the JWT bein  accepted, instead of being rejected. (Security problem!)

Furthermore, the `decode(audience=...`) arg allows both a string and a list of strings, but the audience claim in the JWT payload is always assumed to be a single string, which is against the spec:

> In the general case, the aud value is an array of case-sensitive strings, each containing a StringOrURI value. In the special case when the JWT has one audience, the aud value MAY be a single case-sensitive string containing a StringOrURI value. The interpretation of audience values is generally application specific. Use of this claim is OPTIONAL.

Offending code:

```python
    if audience is not None:
        if isinstance(audience, list):
            audiences = audience
        else:
            audiences = [audience]

        if payload.get('aud') not in audiences:
            raise InvalidAudience('Invalid audience')
```

Hopefully you understand what I meant when I said pyjwt "reverses" the checks.

Let me know your thoughts; I can come up with a PR when we agree on the correct approach and understanding of the spec.